### PR TITLE
rating search

### DIFF
--- a/app/express/src/routes/level-search.js
+++ b/app/express/src/routes/level-search.js
@@ -54,7 +54,7 @@ router.get('/total_level/:rating', async (req, res) => {
 
         res.json({
             rating: rating,
-            latest_companies: companies
+            companies: companies
         });
 
     } catch (error) {


### PR DESCRIPTION
route: GET /api/search/level/total_level/:level
 Search companies based on their ESG rating, returning only the latest record per company.